### PR TITLE
refactor: use full name instead of SPP abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### BREAKING
+
+- Rename all occurences of spp to service_principal for more clarity.
+- Using submodules directly is only possible with Terraform v1.0 or above.
+
+### Added
+
+- Added CHANGELOG.md
+
+## [v0.1.0]
+
+- Initial Release
+
+[unreleased]: https://github.com/meshcloud/terraform-azure-meshplatform/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/meshcloud/terraform-azure-meshplatform/releases/tag/v0.1.0

--- a/TERRAFORM_DOCS.md
+++ b/TERRAFORM_DOCS.md
@@ -4,22 +4,22 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 0.9.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.12.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.3.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#module\_idp\_lookup\_service\_principal) | ./modules/meshcloud-idp-lookup-service_principal/ | n/a |
-| <a name="module_kraken_service_principal"></a> [kraken\_service\_principal](#module\_kraken\_service\_principal) | ./modules/meshcloud-kraken-service_principal/ | n/a |
-| <a name="module_replicator_service_principal"></a> [replicator\_service\_principal](#module\_replicator\_service\_principal) | ./modules/meshcloud-replicator-service_principal/ | n/a |
+| <a name="module_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#module\_idp\_lookup\_service\_principal) | ./modules/meshcloud-idp-lookup-service-principal/ | n/a |
+| <a name="module_kraken_service_principal"></a> [kraken\_service\_principal](#module\_kraken\_service\_principal) | ./modules/meshcloud-kraken-service-principal/ | n/a |
+| <a name="module_replicator_service_principal"></a> [replicator\_service\_principal](#module\_replicator\_service\_principal) | ./modules/meshcloud-replicator-service-principal/ | n/a |
 | <a name="module_uami_blueprint_user_principal"></a> [uami\_blueprint\_user\_principal](#module\_uami\_blueprint\_user\_principal) | ./modules/uami-blueprint-user-principal/ | n/a |
 
 ## Resources
@@ -27,7 +27,7 @@
 | Name | Type |
 |------|------|
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/client_config) | data source |
-| [azurerm_management_group.root](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/data-sources/management_group) | data source |
+| [azurerm_management_group.root](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/data-sources/management_group) | data source |
 
 ## Inputs
 

--- a/TERRAFORM_DOCS.md
+++ b/TERRAFORM_DOCS.md
@@ -10,16 +10,16 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.97.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 0.9.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.12.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_idp_lookup_spp"></a> [idp\_lookup\_spp](#module\_idp\_lookup\_spp) | ./modules/meshcloud-idp-lookup-spp/ | n/a |
-| <a name="module_kraken_spp"></a> [kraken\_spp](#module\_kraken\_spp) | ./modules/meshcloud-kraken-spp/ | n/a |
-| <a name="module_replicator_spp"></a> [replicator\_spp](#module\_replicator\_spp) | ./modules/meshcloud-replicator-spp/ | n/a |
+| <a name="module_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#module\_idp\_lookup\_service\_principal) | ./modules/meshcloud-idp-lookup-service_principal/ | n/a |
+| <a name="module_kraken_service_principal"></a> [kraken\_service\_principal](#module\_kraken\_service\_principal) | ./modules/meshcloud-kraken-service_principal/ | n/a |
+| <a name="module_replicator_service_principal"></a> [replicator\_service\_principal](#module\_replicator\_service\_principal) | ./modules/meshcloud-replicator-service_principal/ | n/a |
 | <a name="module_uami_blueprint_user_principal"></a> [uami\_blueprint\_user\_principal](#module\_uami\_blueprint\_user\_principal) | ./modules/uami-blueprint-user-principal/ | n/a |
 
 ## Resources
@@ -33,13 +33,13 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the SPP needs. | `list(string)` | `[]` | no |
-| <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the replicator SPP needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
-| <a name="input_idplookup_enabled"></a> [idplookup\_enabled](#input\_idplookup\_enabled) | Whether to create idplookup SPP or not. | `bool` | `true` | no |
-| <a name="input_kraken_enabled"></a> [kraken\_enabled](#input\_kraken\_enabled) | Whether to create kraken SPP or not. | `bool` | `true` | no |
+| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
+| <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the replicator Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
+| <a name="input_idplookup_enabled"></a> [idplookup\_enabled](#input\_idplookup\_enabled) | Whether to create idplookup Service Principal or not. | `bool` | `true` | no |
+| <a name="input_kraken_enabled"></a> [kraken\_enabled](#input\_kraken\_enabled) | Whether to create kraken Service Principal or not. | `bool` | `true` | no |
 | <a name="input_mgmt_group_name"></a> [mgmt\_group\_name](#input\_mgmt\_group\_name) | The name or UUID of the Management Group. | `string` | n/a | yes |
-| <a name="input_replicator_enabled"></a> [replicator\_enabled](#input\_replicator\_enabled) | Whether to create replicator SPP or not. | `bool` | `true` | no |
-| <a name="input_spp_name_suffix"></a> [spp\_name\_suffix](#input\_spp\_name\_suffix) | Service principal name suffix. Make sure this is unique. | `string` | n/a | yes |
+| <a name="input_replicator_enabled"></a> [replicator\_enabled](#input\_replicator\_enabled) | Whether to create replicator Service Principal or not. | `bool` | `true` | no |
+| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. Make sure this is unique. | `string` | n/a | yes |
 | <a name="input_subscriptions"></a> [subscriptions](#input\_subscriptions) | The scope to which UAMI blueprint service principal role assignment is applied. | `list(any)` | `[]` | no |
 
 ## Outputs
@@ -47,11 +47,11 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_azure_ad_tenant_id"></a> [azure\_ad\_tenant\_id](#output\_azure\_ad\_tenant\_id) | The Azure AD tenant id. |
-| <a name="output_idp_lookup_spp"></a> [idp\_lookup\_spp](#output\_idp\_lookup\_spp) | IDP Lookup Service Principal. |
-| <a name="output_idp_lookup_spp_password"></a> [idp\_lookup\_spp\_password](#output\_idp\_lookup\_spp\_password) | Password for IDP Lookup Service Principal. |
-| <a name="output_kraken_spp"></a> [kraken\_spp](#output\_kraken\_spp) | Kraken Service Principal. |
-| <a name="output_kraken_spp_password"></a> [kraken\_spp\_password](#output\_kraken\_spp\_password) | Password for Kraken Service Principal. |
-| <a name="output_replicator_spp"></a> [replicator\_spp](#output\_replicator\_spp) | Replicator Service Principal. |
-| <a name="output_replicator_spp_password"></a> [replicator\_spp\_password](#output\_replicator\_spp\_password) | Password for Replicator Service Principal. |
+| <a name="output_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#output\_idp\_lookup\_service\_principal) | IDP Lookup Service Principal. |
+| <a name="output_idp_lookup_service_principal_password"></a> [idp\_lookup\_service\_principal\_password](#output\_idp\_lookup\_service\_principal\_password) | Password for IDP Lookup Service Principal. |
+| <a name="output_kraken_service_principal"></a> [kraken\_service\_principal](#output\_kraken\_service\_principal) | Kraken Service Principal. |
+| <a name="output_kraken_service_principal_password"></a> [kraken\_service\_principal\_password](#output\_kraken\_service\_principal\_password) | Password for Kraken Service Principal. |
+| <a name="output_replicator_service_principal"></a> [replicator\_service\_principal](#output\_replicator\_service\_principal) | Replicator Service Principal. |
+| <a name="output_replicator_service_principal_password"></a> [replicator\_service\_principal\_password](#output\_replicator\_service\_principal\_password) | Password for Replicator Service Principal. |
 | <a name="output_uami_blueprint_user_principal"></a> [uami\_blueprint\_user\_principal](#output\_uami\_blueprint\_user\_principal) | UAMI Blueprint Assignment Service Principal. |
 | <a name="output_uami_blueprint_user_principal_password"></a> [uami\_blueprint\_user\_principal\_password](#output\_uami\_blueprint\_user\_principal\_password) | Password for UAMI Blueprint Assignment Service Principal. |

--- a/examples/azure-integration-with-additional-resource-access/main.tf
+++ b/examples/azure-integration-with-additional-resource-access/main.tf
@@ -11,8 +11,8 @@ terraform {
 module "meshplatform" {
   source = "git::https://github.com/meshcloud/terraform-azure-meshplatform.git"
 
-  spp_name_suffix = "<UNIQUE_NAME>"
-  mgmt_group_name = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
+  service_principal_name_suffix = "<UNIQUE_NAME>"
+  mgmt_group_name               = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
 
   additional_required_resource_accesses = [
     # The block below configures replicator access 

--- a/examples/azure-integration-with-additional-resource-access/outputs.tf
+++ b/examples/azure-integration-with-additional-resource-access/outputs.tf
@@ -1,23 +1,23 @@
 
-output "replicator_spp" {
+output "replicator_service_principal" {
   description = "Replicator Service Principal."
-  value       = module.meshplatform.replicator_spp
+  value       = module.meshplatform.replicator_service_principal
 }
 
-output "replicator_spp_password" {
+output "replicator_service_principal_password" {
   description = "Password for Replicator Service Principal."
-  value       = module.meshplatform.replicator_spp_password
+  value       = module.meshplatform.replicator_service_principal_password
   sensitive   = true
 }
 
-output "kraken_spp" {
+output "kraken_service_principal" {
   description = "Kraken Service Principal."
-  value       = module.meshplatform.kraken_spp
+  value       = module.meshplatform.kraken_service_principal
 }
 
-output "kraken_spp_password" {
+output "kraken_service_principal_password" {
   description = "Password for Kraken Service Principal."
-  value       = module.meshplatform.kraken_spp_password
+  value       = module.meshplatform.kraken_service_principal_password
   sensitive   = true
 }
 

--- a/examples/azure-integration-with-uami-blueprint-user-principal/main.tf
+++ b/examples/azure-integration-with-uami-blueprint-user-principal/main.tf
@@ -11,8 +11,8 @@ terraform {
 module "meshplatform" {
   source = "git::https://github.com/meshcloud/terraform-azure-meshplatform.git"
 
-  spp_name_suffix = "<UNIQUE_NAME>"
-  mgmt_group_name = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
+  service_principal_name_suffix = "<UNIQUE_NAME>"
+  mgmt_group_name               = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
 
   subscriptions = ["<SUBSCRIPTION_ID>"]
 }

--- a/examples/azure-integration-with-uami-blueprint-user-principal/outputs.tf
+++ b/examples/azure-integration-with-uami-blueprint-user-principal/outputs.tf
@@ -1,22 +1,22 @@
-output "replicator_spp" {
+output "replicator_service_principal" {
   description = "Replicator Service Principal."
-  value       = module.meshplatform.replicator_spp
+  value       = module.meshplatform.replicator_service_principal
 }
 
-output "replicator_spp_password" {
+output "replicator_service_principal_password" {
   description = "Password for Replicator Service Principal."
-  value       = module.meshplatform.replicator_spp_password
+  value       = module.meshplatform.replicator_service_principal_password
   sensitive   = true
 }
 
-output "kraken_spp" {
+output "kraken_service_principal" {
   description = "Kraken Service Principal."
-  value       = module.meshplatform.kraken_spp
+  value       = module.meshplatform.kraken_service_principal
 }
 
-output "kraken_spp_password" {
+output "kraken_service_principal_password" {
   description = "Password for Kraken Service Principal."
-  value       = module.meshplatform.kraken_spp_password
+  value       = module.meshplatform.kraken_service_principal_password
   sensitive   = true
 }
 

--- a/examples/basic-azure-integration/main.tf
+++ b/examples/basic-azure-integration/main.tf
@@ -14,7 +14,7 @@ terraform {
 module "meshplatform" {
   source = "git::https://github.com/meshcloud/terraform-azure-meshplatform.git"
 
-  spp_name_suffix = "<UNIQUE_NAME>"
-  mgmt_group_name = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
+  service_principal_name_suffix = "<UNIQUE_NAME>"
+  mgmt_group_name               = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
 
 }

--- a/examples/basic-azure-integration/outputs.tf
+++ b/examples/basic-azure-integration/outputs.tf
@@ -1,33 +1,33 @@
-output "replicator_spp" {
+output "replicator_service_principal" {
   description = "Replicator Service Principal."
-  value       = module.meshplatform.replicator_spp
+  value       = module.meshplatform.replicator_service_principal
 }
 
-output "replicator_spp_password" {
+output "replicator_service_principal_password" {
   description = "Password for Replicator Service Principal."
-  value       = module.meshplatform.replicator_spp_password
+  value       = module.meshplatform.replicator_service_principal_password
   sensitive   = true
 }
 
-output "kraken_spp" {
+output "kraken_service_principal" {
   description = "Kraken Service Principal."
-  value       = module.meshplatform.kraken_spp
+  value       = module.meshplatform.kraken_service_principal
 }
 
-output "kraken_spp_password" {
+output "kraken_service_principal_password" {
   description = "Password for Kraken Service Principal."
-  value       = module.meshplatform.kraken_spp_password
+  value       = module.meshplatform.kraken_service_principal_password
   sensitive   = true
 }
 
-output "idp_lookup_spp" {
+output "idp_lookup_service_principal" {
   description = "IDP Lookup Service Principal."
-  value       = module.meshplatform.idp_lookup_spp
+  value       = module.meshplatform.idp_lookup_service_principal
 }
 
-output "idp_lookup_spp_password" {
+output "idp_lookup_service_principal_password" {
   description = "Password for IDP Lookup Service Principal."
-  value       = module.meshplatform.idp_lookup_spp_password
+  value       = module.meshplatform.idp_lookup_service_principal_password
 }
 
 output "uami_blueprint_user_principal" {

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,6 @@ module "idp_lookup_service_principal" {
   source = "./modules/meshcloud-idp-lookup-service-principal/"
 
   service_principal_name_suffix = var.service_principal_name_suffix
-  scope                         = data.azurerm_management_group.root.id
 }
 
 module "uami_blueprint_user_principal" {

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.97.0"
+      version = "3.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/main.tf
+++ b/main.tf
@@ -20,39 +20,39 @@ data "azurerm_management_group" "root" {
   name = var.mgmt_group_name
 }
 
-module "replicator_spp" {
+module "replicator_service_principal" {
   count  = var.replicator_enabled ? 1 : 0
-  source = "./modules/meshcloud-replicator-spp/"
+  source = "./modules/meshcloud-replicator-service-principal/"
 
-  spp_name_suffix = var.spp_name_suffix
-  scope           = data.azurerm_management_group.root.id
+  service_principal_name_suffix = var.service_principal_name_suffix
+  scope                         = data.azurerm_management_group.root.id
 
   additional_required_resource_accesses = var.additional_required_resource_accesses
   additional_permissions                = var.additional_permissions
 }
 
-module "kraken_spp" {
+module "kraken_service_principal" {
   count  = var.kraken_enabled ? 1 : 0
-  source = "./modules/meshcloud-kraken-spp/"
+  source = "./modules/meshcloud-kraken-service-principal/"
 
-  spp_name_suffix = var.spp_name_suffix
-  scope           = data.azurerm_management_group.root.id
+  service_principal_name_suffix = var.service_principal_name_suffix
+  scope                         = data.azurerm_management_group.root.id
 }
 
-module "idp_lookup_spp" {
+module "idp_lookup_service_principal" {
   count  = var.idplookup_enabled ? 1 : 0
-  source = "./modules/meshcloud-idp-lookup-spp/"
+  source = "./modules/meshcloud-idp-lookup-service-principal/"
 
-  spp_name_suffix = var.spp_name_suffix
-  scope           = data.azurerm_management_group.root.id
+  service_principal_name_suffix = var.service_principal_name_suffix
+  scope                         = data.azurerm_management_group.root.id
 }
 
 module "uami_blueprint_user_principal" {
   count  = length(var.subscriptions)
   source = "./modules/uami-blueprint-user-principal/"
 
-  spp_name_suffix = var.spp_name_suffix
-  subscriptions   = var.subscriptions
+  service_principal_name_suffix = var.service_principal_name_suffix
+  subscriptions                 = var.subscriptions
 }
 
 data "azuread_client_config" "current" {}

--- a/modules/meshcloud-idp-lookup-service-principal/README.md
+++ b/modules/meshcloud-idp-lookup-service-principal/README.md
@@ -2,9 +2,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
 
 ## Providers
 
@@ -31,7 +31,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
 | <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/meshcloud-idp-lookup-service-principal/README.md
+++ b/modules/meshcloud-idp-lookup-service-principal/README.md
@@ -24,14 +24,15 @@ No modules.
 | [azuread_application.meshcloud_idp_lookup](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
 | [azuread_service_principal.meshcloud_idp_lookup](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal_password.spp_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
+| [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
 | [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/application_published_app_ids) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_spp_name_suffix"></a> [spp\_name\_suffix](#input\_spp\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
+| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
+| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/meshcloud-idp-lookup-service-principal/module.tf
+++ b/modules/meshcloud-idp-lookup-service-principal/module.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.97.0"
+      version = "3.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/meshcloud-idp-lookup-service-principal/module.tf
+++ b/modules/meshcloud-idp-lookup-service-principal/module.tf
@@ -20,7 +20,7 @@ resource "azuread_service_principal" "msgraph" {
 }
 
 resource "azuread_application" "meshcloud_idp_lookup" {
-  display_name = "idplookup.${var.spp_name_suffix}"
+  display_name = "idplookup.${var.service_principal_name_suffix}"
 
   web {
     implicit_grant {
@@ -60,7 +60,7 @@ resource "azuread_app_role_assignment" "meshcloud_idp_lookup" {
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
-resource "azuread_service_principal_password" "spp_pw" {
+resource "azuread_service_principal_password" "service_principal_pw" {
   service_principal_id = azuread_service_principal.meshcloud_idp_lookup.id
   end_date             = "2999-01-01T01:02:03Z" # no expiry
 }

--- a/modules/meshcloud-idp-lookup-service-principal/outputs.tf
+++ b/modules/meshcloud-idp-lookup-service-principal/outputs.tf
@@ -3,12 +3,12 @@ output "service_principal" {
   value = {
     object_id = azuread_service_principal.meshcloud_idp_lookup.id
     app_id    = azuread_service_principal.meshcloud_idp_lookup.application_id
-    password  = "Execute `terraform output idp_lookup_spp_password` to see the password"
+    password  = "Execute `terraform output idp_lookup_service_principal_password` to see the password"
   }
 }
 
 output "service_principal_password" {
   description = "Password for the Service Principal."
-  value       = azuread_service_principal_password.spp_pw.value
+  value       = azuread_service_principal_password.service_principal_pw.value
   sensitive   = true
 }

--- a/modules/meshcloud-idp-lookup-service-principal/variables.tf
+++ b/modules/meshcloud-idp-lookup-service-principal/variables.tf
@@ -1,0 +1,9 @@
+variable "service_principal_name_suffix" {
+  type        = string
+  description = "Service principal name suffix."
+}
+
+variable "scope" {
+  type        = string
+  description = "The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
+}

--- a/modules/meshcloud-idp-lookup-service-principal/variables.tf
+++ b/modules/meshcloud-idp-lookup-service-principal/variables.tf
@@ -2,8 +2,3 @@ variable "service_principal_name_suffix" {
   type        = string
   description = "Service principal name suffix."
 }
-
-variable "scope" {
-  type        = string
-  description = "The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
-}

--- a/modules/meshcloud-idp-lookup-spp/variables.tf
+++ b/modules/meshcloud-idp-lookup-spp/variables.tf
@@ -1,9 +1,0 @@
-variable "spp_name_suffix" {
-  type        = string
-  description = "Service principal name suffix."
-}
-
-variable "scope" {
-  type        = string
-  description = "The scope to which SPP permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
-}

--- a/modules/meshcloud-kraken-service-principal/README.md
+++ b/modules/meshcloud-kraken-service-principal/README.md
@@ -23,7 +23,7 @@ No modules.
 |------|------|
 | [azuread_application.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
 | [azuread_service_principal.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal_password.spp_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
+| [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
 | [azurerm_role_assignment.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.meshcloud_kraken_cloud_inventory](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.meshcloud_kraken_cloud_inventory_role](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_definition) | resource |
@@ -32,8 +32,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which SPP permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
-| <a name="input_spp_name_suffix"></a> [spp\_name\_suffix](#input\_spp\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
+| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
+| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/meshcloud-kraken-service-principal/README.md
+++ b/modules/meshcloud-kraken-service-principal/README.md
@@ -2,16 +2,16 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.97.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.3.0 |
 
 ## Modules
 
@@ -24,15 +24,15 @@ No modules.
 | [azuread_application.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
 | [azuread_service_principal.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
-| [azurerm_role_assignment.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.meshcloud_kraken_cloud_inventory](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.meshcloud_kraken_cloud_inventory_role](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_definition) | resource |
+| [azurerm_role_assignment.meshcloud_kraken](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.meshcloud_kraken_cloud_inventory](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.meshcloud_kraken_cloud_inventory_role](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/resources/role_definition) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
+| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is the management group id of form `/providers/Microsoft.Management/managementGroups/<tenantId>` that sits atop the subscriptions. | `string` | n/a | yes |
 | <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/meshcloud-kraken-service-principal/module.tf
+++ b/modules/meshcloud-kraken-service-principal/module.tf
@@ -19,7 +19,7 @@ terraform {
 # HOWEVER, since Microsoft decided you cannot assign the 'Microsoft.Billing/billingPeriods/read' via the api (Status=400 Code="InvalidActionOrNotAction" Message="'Microsoft.Billing/billingPeriods/read' does not match any of the actions supported by the providers.")
 # we have to use a built in role for now that has that permission. If in the future they fix this problem, we can use the following custom role snippet
 # resource azurerm_role_definition meshcloud_kraken {
-#   name        = "kraken.${var.spp_name_suffix}"
+#   name        = "kraken.${var.service_principal_name_suffix}"
 #   scope       = var.scope
 #   description = "Permissions required by meshcloud in order to supply billing and usage data via its kraken module"
 
@@ -51,7 +51,7 @@ resource "azurerm_role_assignment" "meshcloud_kraken" {
 
 # If more resources are collected in the future, the permissions to read those should be added here.
 resource "azurerm_role_definition" "meshcloud_kraken_cloud_inventory_role" {
-  name        = "kraken.${var.spp_name_suffix}_cloud_inventory_role"
+  name        = "kraken.${var.service_principal_name_suffix}_cloud_inventory_role"
   scope       = var.scope
   description = "Permissions required by meshcloud in order to collect information about resources in the kraken module"
 
@@ -75,7 +75,7 @@ resource "azurerm_role_assignment" "meshcloud_kraken_cloud_inventory" {
 }
 
 resource "azuread_application" "meshcloud_kraken" {
-  display_name = "kraken.${var.spp_name_suffix}"
+  display_name = "kraken.${var.service_principal_name_suffix}"
 
   web {
     implicit_grant {
@@ -89,7 +89,7 @@ resource "azuread_service_principal" "meshcloud_kraken" {
   application_id = azuread_application.meshcloud_kraken.application_id
 }
 
-resource "azuread_service_principal_password" "spp_pw" {
+resource "azuread_service_principal_password" "service_principal_pw" {
   service_principal_id = azuread_service_principal.meshcloud_kraken.id
   end_date             = "2999-01-01T01:02:03Z" # no expiry
 }

--- a/modules/meshcloud-kraken-service-principal/module.tf
+++ b/modules/meshcloud-kraken-service-principal/module.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.97.0"
+      version = "3.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/meshcloud-kraken-service-principal/outputs.tf
+++ b/modules/meshcloud-kraken-service-principal/outputs.tf
@@ -3,12 +3,12 @@ output "service_principal" {
   value = {
     object_id = azuread_service_principal.meshcloud_kraken.id
     app_id    = azuread_service_principal.meshcloud_kraken.application_id
-    password  = "Execute `terraform output kraken_spp_password` to see the password"
+    password  = "Execute `terraform output kraken_service_principal_password` to see the password"
   }
 }
 
 output "service_principal_password" {
   description = "Password for the Service Principal."
-  value       = azuread_service_principal_password.spp_pw.value
+  value       = azuread_service_principal_password.service_principal_pw.value
   sensitive   = true
 }

--- a/modules/meshcloud-kraken-service-principal/variables.tf
+++ b/modules/meshcloud-kraken-service-principal/variables.tf
@@ -1,0 +1,9 @@
+variable "service_principal_name_suffix" {
+  type        = string
+  description = "Service principal name suffix."
+}
+
+variable "scope" {
+  type        = string
+  description = "The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
+}

--- a/modules/meshcloud-kraken-service-principal/variables.tf
+++ b/modules/meshcloud-kraken-service-principal/variables.tf
@@ -5,5 +5,5 @@ variable "service_principal_name_suffix" {
 
 variable "scope" {
   type        = string
-  description = "The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
+  description = "The scope to which Service Principal permissions should be assigned to. Usually this is the management group id of form `/providers/Microsoft.Management/managementGroups/<tenantId>` that sits atop the subscriptions."
 }

--- a/modules/meshcloud-kraken-spp/variables.tf
+++ b/modules/meshcloud-kraken-spp/variables.tf
@@ -1,9 +1,0 @@
-variable "spp_name_suffix" {
-  type        = string
-  description = "Service principal name suffix."
-}
-
-variable "scope" {
-  type        = string
-  description = "The scope to which SPP permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
-}

--- a/modules/meshcloud-replicator-service-principal/README.md
+++ b/modules/meshcloud-replicator-service-principal/README.md
@@ -27,7 +27,7 @@ No modules.
 | [azuread_application.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
 | [azuread_service_principal.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal_password.spp_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
+| [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
 | [azurerm_role_assignment.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_definition.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_definition) | resource |
 | [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/application_published_app_ids) | data source |
@@ -36,10 +36,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the SPP needs. | `list(string)` | `[]` | no |
-| <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the SPP needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
-| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which SPP permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
-| <a name="input_spp_name_suffix"></a> [spp\_name\_suffix](#input\_spp\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
+| <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
+| <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
+| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
+| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/meshcloud-replicator-service-principal/README.md
+++ b/modules/meshcloud-replicator-service-principal/README.md
@@ -2,16 +2,16 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.97.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.3.0 |
 
 ## Modules
 
@@ -28,8 +28,8 @@ No modules.
 | [azuread_service_principal.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
-| [azurerm_role_assignment.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_definition) | resource |
+| [azurerm_role_assignment.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.meshcloud_replicator](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/resources/role_definition) | resource |
 | [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/application_published_app_ids) | data source |
 
 ## Inputs
@@ -38,7 +38,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
 | <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
-| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions. | `string` | n/a | yes |
+| <a name="input_scope"></a> [scope](#input\_scope) | The scope to which Service Principal permissions should be assigned to. Usually this is the management group id of form `/providers/Microsoft.Management/managementGroups/<tenantId>` that sits atop the subscriptions. | `string` | n/a | yes |
 | <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/meshcloud-replicator-service-principal/module.tf
+++ b/modules/meshcloud-replicator-service-principal/module.tf
@@ -1,10 +1,10 @@
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.97.0"
+      version = "3.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/meshcloud-replicator-service-principal/module.tf
+++ b/modules/meshcloud-replicator-service-principal/module.tf
@@ -14,7 +14,7 @@ terraform {
 }
 
 resource "azurerm_role_definition" "meshcloud_replicator" {
-  name        = "replicator.${var.spp_name_suffix}"
+  name        = "replicator.${var.service_principal_name_suffix}"
   scope       = var.scope
   description = "Permissions required by meshcloud in order to configure subscriptions and manage users"
 
@@ -61,7 +61,7 @@ resource "azuread_service_principal" "msgraph" {
 }
 
 resource "azuread_application" "meshcloud_replicator" {
-  display_name = "replicator.${var.spp_name_suffix}"
+  display_name = "replicator.${var.service_principal_name_suffix}"
 
   web {
     implicit_grant {
@@ -147,7 +147,7 @@ resource "azuread_app_role_assignment" "meshcloud_replicator-user" {
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }
 
-resource "azuread_service_principal_password" "spp_pw" {
+resource "azuread_service_principal_password" "service_principal_pw" {
   service_principal_id = azuread_service_principal.meshcloud_replicator.id
   end_date             = "2999-01-01T01:02:03Z" # no expiry
 }

--- a/modules/meshcloud-replicator-service-principal/outputs.tf
+++ b/modules/meshcloud-replicator-service-principal/outputs.tf
@@ -3,13 +3,13 @@ output "service_principal" {
   value = {
     object_id = azuread_service_principal.meshcloud_replicator.id
     app_id    = azuread_service_principal.meshcloud_replicator.application_id
-    password  = "Execute `terraform output replicator_spp_password` to see the password"
+    password  = "Execute `terraform output replicator_service_principal_password` to see the password"
   }
 }
 
 output "service_principal_password" {
   description = "Password for the Service Principal."
-  value       = azuread_service_principal_password.spp_pw.value
+  value       = azuread_service_principal_password.service_principal_pw.value
   sensitive   = true
 }
 

--- a/modules/meshcloud-replicator-service-principal/variables.tf
+++ b/modules/meshcloud-replicator-service-principal/variables.tf
@@ -5,7 +5,7 @@ variable "service_principal_name_suffix" {
 
 variable "scope" {
   type        = string
-  description = "The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
+  description = "The scope to which Service Principal permissions should be assigned to. Usually this is the management group id of form `/providers/Microsoft.Management/managementGroups/<tenantId>` that sits atop the subscriptions."
 }
 
 variable "additional_required_resource_accesses" {

--- a/modules/meshcloud-replicator-service-principal/variables.tf
+++ b/modules/meshcloud-replicator-service-principal/variables.tf
@@ -1,21 +1,21 @@
-variable "spp_name_suffix" {
+variable "service_principal_name_suffix" {
   type        = string
   description = "Service principal name suffix."
 }
 
 variable "scope" {
   type        = string
-  description = "The scope to which SPP permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
+  description = "The scope to which Service Principal permissions should be assigned to. Usually this is a management group that sits atop the subscriptions."
 }
 
 variable "additional_required_resource_accesses" {
   type        = list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))
   default     = []
-  description = "Additional AAD-Level Resource Accesses the SPP needs."
+  description = "Additional AAD-Level Resource Accesses the Service Principal needs."
 }
 
 variable "additional_permissions" {
   type        = list(string)
   default     = []
-  description = "Additional Subscription-Level Permissions the SPP needs."
+  description = "Additional Subscription-Level Permissions the Service Principal needs."
 }

--- a/modules/meshcloud-sso/README.md
+++ b/modules/meshcloud-sso/README.md
@@ -30,7 +30,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_meshstack_redirect_uri"></a> [meshstack\_redirect\_uri](#input\_meshstack\_redirect\_uri) | Redirect URI that will be provided by meshcloud. It is individual per meshStack. | `string` | n/a | yes |
-| <a name="input_spp_name_suffix"></a> [spp\_name\_suffix](#input\_spp\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
+| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/meshcloud-sso/README.md
+++ b/modules/meshcloud-sso/README.md
@@ -2,9 +2,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
 
 ## Providers
 

--- a/modules/meshcloud-sso/module.tf
+++ b/modules/meshcloud-sso/module.tf
@@ -20,7 +20,7 @@ resource "azuread_service_principal" "msgraph" {
 }
 
 resource "azuread_application" "meshcloud_sso" {
-  display_name = "sso.${var.spp_name_suffix}"
+  display_name = "sso.${var.service_principal_name_suffix}"
 
   required_resource_access {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph

--- a/modules/meshcloud-sso/module.tf
+++ b/modules/meshcloud-sso/module.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.97.0"
+      version = "3.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/meshcloud-sso/variables.tf
+++ b/modules/meshcloud-sso/variables.tf
@@ -1,4 +1,4 @@
-variable "spp_name_suffix" {
+variable "service_principal_name_suffix" {
   type        = string
   description = "Service principal name suffix."
 }

--- a/modules/uami-blueprint-user-principal/README.md
+++ b/modules/uami-blueprint-user-principal/README.md
@@ -23,14 +23,14 @@ No modules.
 |------|------|
 | [azuread_application.uami_blueprint_principal](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
 | [azuread_service_principal.uami_blueprint_principal](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
-| [azuread_service_principal_password.spp_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
-| [azurerm_role_assignment.spp_pw](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
+| [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
+| [azurerm_role_assignment.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_spp_name_suffix"></a> [spp\_name\_suffix](#input\_spp\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
+| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. | `string` | n/a | yes |
 | <a name="input_subscriptions"></a> [subscriptions](#input\_subscriptions) | The scope to which UAMI blueprint service principal role assignment is applied. | `list(any)` | n/a | yes |
 
 ## Outputs

--- a/modules/uami-blueprint-user-principal/README.md
+++ b/modules/uami-blueprint-user-principal/README.md
@@ -2,16 +2,16 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 2.97.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 2.97.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.3.0 |
 
 ## Modules
 
@@ -24,7 +24,7 @@ No modules.
 | [azuread_application.uami_blueprint_principal](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/application) | resource |
 | [azuread_service_principal.uami_blueprint_principal](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal) | resource |
 | [azuread_service_principal_password.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/resources/service_principal_password) | resource |
-| [azurerm_role_assignment.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azurerm/2.97.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.service_principal_pw](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/resources/role_assignment) | resource |
 
 ## Inputs
 

--- a/modules/uami-blueprint-user-principal/module.tf
+++ b/modules/uami-blueprint-user-principal/module.tf
@@ -13,19 +13,19 @@ terraform {
 }
 
 resource "azuread_application" "uami_blueprint_principal" {
-  display_name = "uami-blueprint.${var.spp_name_suffix}"
+  display_name = "uami-blueprint.${var.service_principal_name_suffix}"
 }
 
 resource "azuread_service_principal" "uami_blueprint_principal" {
   application_id = azuread_application.uami_blueprint_principal.application_id
 }
 
-resource "azuread_service_principal_password" "spp_pw" {
+resource "azuread_service_principal_password" "service_principal_pw" {
   service_principal_id = azuread_service_principal.uami_blueprint_principal.id
   end_date             = "2999-01-01T01:02:03Z" # no expiry
 }
 
-resource "azurerm_role_assignment" "spp_pw" {
+resource "azurerm_role_assignment" "service_principal_pw" {
   count                = length(var.subscriptions)
   principal_id         = azuread_service_principal.uami_blueprint_principal.id
   scope                = "/subscriptions/${var.subscriptions[count.index]}"

--- a/modules/uami-blueprint-user-principal/module.tf
+++ b/modules/uami-blueprint-user-principal/module.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.97.0"
+      version = "3.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/modules/uami-blueprint-user-principal/outputs.tf
+++ b/modules/uami-blueprint-user-principal/outputs.tf
@@ -7,6 +7,6 @@ output "service_principal" {
 }
 
 output "service_principal_password" {
-  value     = azuread_service_principal_password.spp_pw.value
+  value     = azuread_service_principal_password.service_principal_pw.value
   sensitive = true
 }

--- a/modules/uami-blueprint-user-principal/variables.tf
+++ b/modules/uami-blueprint-user-principal/variables.tf
@@ -1,4 +1,4 @@
-variable "spp_name_suffix" {
+variable "service_principal_name_suffix" {
   type        = string
   description = "Service principal name suffix."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,39 +1,39 @@
 
-output "replicator_spp" {
+output "replicator_service_principal" {
   description = "Replicator Service Principal."
-  value       = length(module.replicator_spp) > 0 ? module.replicator_spp[0].service_principal : null
+  value       = length(module.replicator_service_principal) > 0 ? module.replicator_service_principal[0].service_principal : null
 }
 
-output "replicator_spp_password" {
+output "replicator_service_principal_password" {
   description = "Password for Replicator Service Principal."
-  value       = length(module.replicator_spp) > 0 ? module.replicator_spp[0].service_principal_password : null
+  value       = length(module.replicator_service_principal) > 0 ? module.replicator_service_principal[0].service_principal_password : null
   sensitive   = true
 }
 
 # output "blueprint_service_principal_object_id" {
 #   description = "Object ID of the BluePrint Service Principal in this AAD."
-#   value       = length(module.replicator_spp) > 0 ? module.replicator_spp[0].azuread_application.blueprint_service_principal.object_id : null
+#   value       = length(module.replicator_service_principal) > 0 ? module.replicator_service_principal[0].azuread_application.blueprint_service_principal.object_id : null
 # }
 
-output "kraken_spp" {
+output "kraken_service_principal" {
   description = "Kraken Service Principal."
-  value       = length(module.kraken_spp) > 0 ? module.kraken_spp[0].service_principal : null
+  value       = length(module.kraken_service_principal) > 0 ? module.kraken_service_principal[0].service_principal : null
 }
 
-output "kraken_spp_password" {
+output "kraken_service_principal_password" {
   description = "Password for Kraken Service Principal."
-  value       = length(module.kraken_spp) > 0 ? module.kraken_spp[0].service_principal_password : null
+  value       = length(module.kraken_service_principal) > 0 ? module.kraken_service_principal[0].service_principal_password : null
   sensitive   = true
 }
 
-output "idp_lookup_spp" {
+output "idp_lookup_service_principal" {
   description = "IDP Lookup Service Principal."
-  value       = length(module.idp_lookup_spp) > 0 ? module.idp_lookup_spp[0].service_principal : null
+  value       = length(module.idp_lookup_service_principal) > 0 ? module.idp_lookup_service_principal[0].service_principal : null
 }
 
-output "idp_lookup_spp_password" {
+output "idp_lookup_service_principal_password" {
   description = "Password for IDP Lookup Service Principal."
-  value       = length(module.idp_lookup_spp) > 0 ? module.idp_lookup_spp[0].service_principal_password : null
+  value       = length(module.idp_lookup_service_principal) > 0 ? module.idp_lookup_service_principal[0].service_principal_password : null
   sensitive   = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "spp_name_suffix" {
+variable "service_principal_name_suffix" {
   type        = string
   description = "Service principal name suffix. Make sure this is unique."
 }
@@ -16,19 +16,19 @@ variable "mgmt_group_name" {
 variable "replicator_enabled" {
   type        = bool
   default     = true
-  description = "Whether to create replicator SPP or not."
+  description = "Whether to create replicator Service Principal or not."
 }
 
 variable "kraken_enabled" {
   type        = bool
   default     = true
-  description = "Whether to create kraken SPP or not."
+  description = "Whether to create kraken Service Principal or not."
 }
 
 variable "idplookup_enabled" {
   type        = bool
   default     = true
-  description = "Whether to create idplookup SPP or not."
+  description = "Whether to create idplookup Service Principal or not."
 }
 
 # additional_required_resource_accesses are useful if replicator needs 
@@ -37,13 +37,13 @@ variable "idplookup_enabled" {
 variable "additional_required_resource_accesses" {
   type        = list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))
   default     = []
-  description = "Additional AAD-Level Resource Accesses the replicator SPP needs."
+  description = "Additional AAD-Level Resource Accesses the replicator Service Principal needs."
 }
 
 variable "additional_permissions" {
   type        = list(string)
   default     = []
-  description = "Additional Subscription-Level Permissions the SPP needs."
+  description = "Additional Subscription-Level Permissions the Service Principal needs."
 }
 
 variable "subscriptions" {


### PR DESCRIPTION
More clarity when using the full name as SPP does not produce relevant results in Azure terms