### PR TITLE
config: default setup should not create IDP Lookup

### DIFF
--- a/examples/basic-azure-integration/main.tf
+++ b/examples/basic-azure-integration/main.tf
@@ -17,4 +17,6 @@ module "meshplatform" {
   service_principal_name_suffix = "<UNIQUE_NAME>"
   mgmt_group_name               = "<MANAGEMENT_GROUP_NAME>|<MANAGEMENT_GROUP_UUID>"
 
+  # If you want to integrate your AAD as SSO for meshStack, set the below value to true to create the necessary Application.
+  idplookup_enabled = false
 }


### PR DESCRIPTION
The idea is, that for your first meshStack, SSO is not the first thing that you set up. So disabling it first and enabling it when needed makes more sense.