### PR TITLE
docs: kraken credentials are used in metering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename all occurences of spp to service_principal for more clarity.
 - Using submodules directly is only possible with Terraform v1.0 or above.
 
+### Changed
+
+- Documentation for kraken now mentions the use-case: metering.^
+
 ### Added
 
 - Added CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Documentation for kraken now mentions the use-case: metering.^
+- Documentation for kraken now mentions the use-case: metering.
 
 ### Added
 

--- a/TERRAFORM_DOCS.md
+++ b/TERRAFORM_DOCS.md
@@ -49,8 +49,8 @@
 | <a name="output_azure_ad_tenant_id"></a> [azure\_ad\_tenant\_id](#output\_azure\_ad\_tenant\_id) | The Azure AD tenant id. |
 | <a name="output_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#output\_idp\_lookup\_service\_principal) | IDP Lookup Service Principal. |
 | <a name="output_idp_lookup_service_principal_password"></a> [idp\_lookup\_service\_principal\_password](#output\_idp\_lookup\_service\_principal\_password) | Password for IDP Lookup Service Principal. |
-| <a name="output_kraken_service_principal"></a> [kraken\_service\_principal](#output\_kraken\_service\_principal) | Kraken Service Principal. |
-| <a name="output_kraken_service_principal_password"></a> [kraken\_service\_principal\_password](#output\_kraken\_service\_principal\_password) | Password for Kraken Service Principal. |
+| <a name="output_kraken_service_principal"></a> [kraken\_service\_principal](#output\_kraken\_service\_principal) | Metering Service Principal. |
+| <a name="output_kraken_service_principal_password"></a> [kraken\_service\_principal\_password](#output\_kraken\_service\_principal\_password) | Password for Metering Service Principal. |
 | <a name="output_replicator_service_principal"></a> [replicator\_service\_principal](#output\_replicator\_service\_principal) | Replicator Service Principal. |
 | <a name="output_replicator_service_principal_password"></a> [replicator\_service\_principal\_password](#output\_replicator\_service\_principal\_password) | Password for Replicator Service Principal. |
 | <a name="output_uami_blueprint_user_principal"></a> [uami\_blueprint\_user\_principal](#output\_uami\_blueprint\_user\_principal) | UAMI Blueprint Assignment Service Principal. |

--- a/TERRAFORM_DOCS.md
+++ b/TERRAFORM_DOCS.md
@@ -36,7 +36,7 @@
 | <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
 | <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the replicator Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
 | <a name="input_idplookup_enabled"></a> [idplookup\_enabled](#input\_idplookup\_enabled) | Whether to create idplookup Service Principal or not. | `bool` | `true` | no |
-| <a name="input_kraken_enabled"></a> [kraken\_enabled](#input\_kraken\_enabled) | Whether to create kraken Service Principal or not. | `bool` | `true` | no |
+| <a name="input_kraken_enabled"></a> [kraken\_enabled](#input\_kraken\_enabled) | Whether to create Metering Service Principal or not. | `bool` | `true` | no |
 | <a name="input_mgmt_group_name"></a> [mgmt\_group\_name](#input\_mgmt\_group\_name) | The name or UUID of the Management Group. | `string` | n/a | yes |
 | <a name="input_replicator_enabled"></a> [replicator\_enabled](#input\_replicator\_enabled) | Whether to create replicator Service Principal or not. | `bool` | `true` | no |
 | <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. Make sure this is unique. | `string` | n/a | yes |

--- a/examples/azure-integration-with-additional-resource-access/outputs.tf
+++ b/examples/azure-integration-with-additional-resource-access/outputs.tf
@@ -11,12 +11,12 @@ output "replicator_service_principal_password" {
 }
 
 output "kraken_service_principal" {
-  description = "Kraken Service Principal."
+  description = "Metering Service Principal."
   value       = module.meshplatform.kraken_service_principal
 }
 
 output "kraken_service_principal_password" {
-  description = "Password for Kraken Service Principal."
+  description = "Password for Metering Service Principal."
   value       = module.meshplatform.kraken_service_principal_password
   sensitive   = true
 }

--- a/examples/azure-integration-with-uami-blueprint-user-principal/outputs.tf
+++ b/examples/azure-integration-with-uami-blueprint-user-principal/outputs.tf
@@ -10,12 +10,12 @@ output "replicator_service_principal_password" {
 }
 
 output "kraken_service_principal" {
-  description = "Kraken Service Principal."
+  description = "Metering Service Principal."
   value       = module.meshplatform.kraken_service_principal
 }
 
 output "kraken_service_principal_password" {
-  description = "Password for Kraken Service Principal."
+  description = "Password for Metering Service Principal."
   value       = module.meshplatform.kraken_service_principal_password
   sensitive   = true
 }

--- a/examples/basic-azure-integration/outputs.tf
+++ b/examples/basic-azure-integration/outputs.tf
@@ -10,12 +10,12 @@ output "replicator_service_principal_password" {
 }
 
 output "kraken_service_principal" {
-  description = "Kraken Service Principal."
+  description = "Metering Service Principal."
   value       = module.meshplatform.kraken_service_principal
 }
 
 output "kraken_service_principal_password" {
-  description = "Password for Kraken Service Principal."
+  description = "Password for Metering Service Principal."
   value       = module.meshplatform.kraken_service_principal_password
   sensitive   = true
 }

--- a/modules/meshcloud-kraken-service-principal/module.tf
+++ b/modules/meshcloud-kraken-service-principal/module.tf
@@ -53,7 +53,7 @@ resource "azurerm_role_assignment" "meshcloud_kraken" {
 resource "azurerm_role_definition" "meshcloud_kraken_cloud_inventory_role" {
   name        = "kraken.${var.service_principal_name_suffix}_cloud_inventory_role"
   scope       = var.scope
-  description = "Permissions required by meshcloud in order to collect information about resources in the kraken module"
+  description = "Permissions required by meshcloud in order to collect information about resources in the metering module"
 
   permissions {
     actions = [

--- a/modules/meshcloud-kraken-spp/README.md
+++ b/modules/meshcloud-kraken-spp/README.md
@@ -1,0 +1,23 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,12 +16,12 @@ output "replicator_service_principal_password" {
 # }
 
 output "kraken_service_principal" {
-  description = "Kraken Service Principal."
+  description = "Metering Service Principal."
   value       = length(module.kraken_service_principal) > 0 ? module.kraken_service_principal[0].service_principal : null
 }
 
 output "kraken_service_principal_password" {
-  description = "Password for Kraken Service Principal."
+  description = "Password for Metering Service Principal."
   value       = length(module.kraken_service_principal) > 0 ? module.kraken_service_principal[0].service_principal_password : null
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "replicator_enabled" {
 variable "kraken_enabled" {
   type        = bool
   default     = true
-  description = "Whether to create kraken Service Principal or not."
+  description = "Whether to create Metering Service Principal or not."
 }
 
 variable "idplookup_enabled" {


### PR DESCRIPTION
For now, only the description mention metering in kraken-related outputs.

Renaming all kraken bits into metering would make sense, but require a breaking change.