### PR TITLE
feat: workload identity federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added privilege escalation prevention policy for replicator
+- New configuration option `workload_identity_federation` to create federated credentials. Unset by default.
+- New configuration option `create_passwords` to enable/disable creation of password credentials. Defaults to `true`.
 
 ## [v0.2.0]
 

--- a/README.md
+++ b/README.md
@@ -96,32 +96,33 @@ Check [examples](./examples/) for different use cases. As a quick start we recom
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.18.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.1 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.46.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.81.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.18.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.3.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.46.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.81.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#module\_idp\_lookup\_service\_principal) | ./modules/meshcloud-idp-lookup-service-principal/ | n/a |
 | <a name="module_metering_service_principal"></a> [metering\_service\_principal](#module\_metering\_service\_principal) | ./modules/meshcloud-metering-service-principal/ | n/a |
 | <a name="module_replicator_service_principal"></a> [replicator\_service\_principal](#module\_replicator\_service\_principal) | ./modules/meshcloud-replicator-service-principal/ | n/a |
-| <a name="module_uami_blueprint_user_principal"></a> [uami\_blueprint\_user\_principal](#module\_uami\_blueprint\_user\_principal) | ./modules/uami-blueprint-user-principal/ | n/a |
+| <a name="module_sso_service_principal"></a> [sso\_service\_principal](#module\_sso\_service\_principal) | ./modules/meshcloud-sso/ | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.18.0/docs/data-sources/client_config) | data source |
-| [azurerm_management_group.root](https://registry.terraform.io/providers/hashicorp/azurerm/3.3.0/docs/data-sources/management_group) | data source |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/client_config) | data source |
+| [azurerm_management_group.metering_assignment_scopes](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/data-sources/management_group) | data source |
+| [azurerm_management_group.replicator_assignment_scopes](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/data-sources/management_group) | data source |
+| [azurerm_management_group.replicator_custom_role_scope](https://registry.terraform.io/providers/hashicorp/azurerm/3.81.0/docs/data-sources/management_group) | data source |
 
 ## Inputs
 
@@ -129,25 +130,29 @@ Check [examples](./examples/) for different use cases. As a quick start we recom
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
 | <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the replicator Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
-| <a name="input_idplookup_enabled"></a> [idplookup\_enabled](#input\_idplookup\_enabled) | Whether to create idplookup Service Principal or not. | `bool` | `true` | no |
+| <a name="input_create_passwords"></a> [create\_passwords](#input\_create\_passwords) | Create passwords for service principals. | `bool` | `true` | no |
+| <a name="input_metering_assignment_scopes"></a> [metering\_assignment\_scopes](#input\_metering\_assignment\_scopes) | Names or UUIDs of the Management Groups that kraken should collect costs for. | `list(string)` | n/a | yes |
 | <a name="input_metering_enabled"></a> [metering\_enabled](#input\_metering\_enabled) | Whether to create Metering Service Principal or not. | `bool` | `true` | no |
-| <a name="input_mgmt_group_name"></a> [mgmt\_group\_name](#input\_mgmt\_group\_name) | The name or UUID of the Management Group. | `string` | n/a | yes |
+| <a name="input_metering_service_principal_name"></a> [metering\_service\_principal\_name](#input\_metering\_service\_principal\_name) | Service principal for collecting cost data. Kraken ist the name of the meshStack component. Name must be unique per Entra ID. | `string` | `"kraken"` | no |
+| <a name="input_replicator_assignment_scopes"></a> [replicator\_assignment\_scopes](#input\_replicator\_assignment\_scopes) | Names or UUIDs of the Management Groups which replicator should manage. | `list(string)` | n/a | yes |
+| <a name="input_replicator_custom_role_scope"></a> [replicator\_custom\_role\_scope](#input\_replicator\_custom\_role\_scope) | Name or UUID of the Management Group of the replicator custom role definition. The custom role definition must be available for all assignment scopes. | `string` | n/a | yes |
 | <a name="input_replicator_enabled"></a> [replicator\_enabled](#input\_replicator\_enabled) | Whether to create replicator Service Principal or not. | `bool` | `true` | no |
-| <a name="input_replicator_rg_enabled"></a> [replicator\_rg\_enabled](#input\_replicator\_rg\_enabled) | Enables the replicator service principal to be used for Azure Resource Group replication. Implicitly enables the `replicator_enabled` flag. | `bool` | `true` | no |
-| <a name="input_service_principal_name_suffix"></a> [service\_principal\_name\_suffix](#input\_service\_principal\_name\_suffix) | Service principal name suffix. Make sure this is unique. | `string` | n/a | yes |
-| <a name="input_subscriptions"></a> [subscriptions](#input\_subscriptions) | The scope to which UAMI blueprint service principal role assignment is applied. | `list(any)` | `[]` | no |
+| <a name="input_replicator_rg_enabled"></a> [replicator\_rg\_enabled](#input\_replicator\_rg\_enabled) | Whether the created replicator Service Principal should be usable for Azure Resource Group based replication. Implicitly enables replicator\_enabled if set to true. | `bool` | `false` | no |
+| <a name="input_replicator_service_principal_name"></a> [replicator\_service\_principal\_name](#input\_replicator\_service\_principal\_name) | Service principal for managing subscriptions. Replicator is the name of the meshStack component. Name must be unique per Entra ID. | `string` | `"replicator"` | no |
+| <a name="input_sso_enabled"></a> [sso\_enabled](#input\_sso\_enabled) | Whether to create SSO Service Principal or not. | `bool` | `true` | no |
+| <a name="input_sso_meshstack_redirect_uri"></a> [sso\_meshstack\_redirect\_uri](#input\_sso\_meshstack\_redirect\_uri) | Redirect URI that was provided by meshcloud. It is individual per meshStack. | `string` | `"<replace with uri>"` | no |
+| <a name="input_sso_service_principal_name"></a> [sso\_service\_principal\_name](#input\_sso\_service\_principal\_name) | Service principal for Entra ID SSO. Name must be unique per Entra ID. | `string` | `"sso"` | no |
+| <a name="input_workload_identity_federation"></a> [workload\_identity\_federation](#input\_workload\_identity\_federation) | Enable workload identity federation by creating federated credentials for enterprise applications. Usually you'd receive the required settings when attempting to configure a platform with workload identity federation in meshStack. | `object({ issuer = string, replicator_subject = string, kraken_subject = string })` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_azure_ad_tenant_id"></a> [azure\_ad\_tenant\_id](#output\_azure\_ad\_tenant\_id) | The Azure AD tenant id. |
-| <a name="output_idp_lookup_service_principal"></a> [idp\_lookup\_service\_principal](#output\_idp\_lookup\_service\_principal) | IDP Lookup Service Principal. |
-| <a name="output_idp_lookup_service_principal_password"></a> [idp\_lookup\_service\_principal\_password](#output\_idp\_lookup\_service\_principal\_password) | Password for IDP Lookup Service Principal. |
 | <a name="output_metering_service_principal"></a> [metering\_service\_principal](#output\_metering\_service\_principal) | Metering Service Principal. |
 | <a name="output_metering_service_principal_password"></a> [metering\_service\_principal\_password](#output\_metering\_service\_principal\_password) | Password for Metering Service Principal. |
 | <a name="output_replicator_service_principal"></a> [replicator\_service\_principal](#output\_replicator\_service\_principal) | Replicator Service Principal. |
 | <a name="output_replicator_service_principal_password"></a> [replicator\_service\_principal\_password](#output\_replicator\_service\_principal\_password) | Password for Replicator Service Principal. |
-| <a name="output_uami_blueprint_user_principal"></a> [uami\_blueprint\_user\_principal](#output\_uami\_blueprint\_user\_principal) | UAMI Blueprint Assignment Service Principal. |
-| <a name="output_uami_blueprint_user_principal_password"></a> [uami\_blueprint\_user\_principal\_password](#output\_uami\_blueprint\_user\_principal\_password) | Password for UAMI Blueprint Assignment Service Principal. |
+| <a name="output_sso_service_principal"></a> [sso\_service\_principal](#output\_sso\_service\_principal) | SSO Service Principal. |
+| <a name="output_sso_service_principal_password"></a> [sso\_service\_principal\_password](#output\_sso\_service\_principal\_password) | Password for SSO Service Principal. |
 <!-- END_TF_DOCS -->

--- a/modules/meshcloud-metering-service-principal/auth.tf
+++ b/modules/meshcloud-metering-service-principal/auth.tf
@@ -1,0 +1,45 @@
+//---------------------------------------------------------------------------
+// Create a password for the Enterprise application
+//---------------------------------------------------------------------------
+resource "time_rotating" "replicator_secret_rotation" {
+  count = var.create_password ? 1 : 0
+
+  rotation_days = 365
+}
+
+resource "azuread_application_password" "application_pw" {
+  count = var.create_password ? 1 : 0
+
+  application_id = azuread_application.meshcloud_metering.id
+  rotate_when_changed = {
+    rotation = time_rotating.replicator_secret_rotation[0].id
+  }
+}
+
+moved {
+  from = azurerm_role_assignment.meshcloud_kraken
+  to   = azurerm_role_assignment.meshcloud_metering
+}
+
+moved {
+  from = azuread_application.meshcloud_kraken
+  to   = azuread_application.meshcloud_metering
+}
+
+moved {
+  from = azuread_service_principal.meshcloud_kraken
+  to   = azuread_service_principal.meshcloud_metering
+}
+
+//---------------------------------------------------------------------------
+// Create federated identity credentials
+//---------------------------------------------------------------------------
+resource "azuread_application_federated_identity_credential" "meshcloud_metering" {
+  count = var.workload_identity_federation == null ? 0 : 1
+
+  application_id = azuread_application.meshcloud_metering.id
+  display_name   = var.service_principal_name
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = var.workload_identity_federation.issuer
+  subject        = var.workload_identity_federation.subject
+}

--- a/modules/meshcloud-metering-service-principal/module.tf
+++ b/modules/meshcloud-metering-service-principal/module.tf
@@ -54,32 +54,3 @@ resource "azuread_service_principal" "meshcloud_metering" {
     enterprise = true
   }
 }
-
-//---------------------------------------------------------------------------
-// Create a password for the Enterprise application
-//---------------------------------------------------------------------------
-resource "time_rotating" "replicator_secret_rotation" {
-  rotation_days = 365
-}
-
-resource "azuread_application_password" "application_pw" {
-  application_id = azuread_application.meshcloud_metering.id
-  rotate_when_changed = {
-    rotation = time_rotating.replicator_secret_rotation.id
-  }
-}
-
-moved {
-  from = azurerm_role_assignment.meshcloud_kraken
-  to   = azurerm_role_assignment.meshcloud_metering
-}
-
-moved {
-  from = azuread_application.meshcloud_kraken
-  to   = azuread_application.meshcloud_metering
-}
-
-moved {
-  from = azuread_service_principal.meshcloud_kraken
-  to   = azuread_service_principal.meshcloud_metering
-}

--- a/modules/meshcloud-metering-service-principal/outputs.tf
+++ b/modules/meshcloud-metering-service-principal/outputs.tf
@@ -3,12 +3,12 @@ output "credentials" {
   value = {
     Enterprise_Application_Object_ID = azuread_service_principal.meshcloud_metering.id
     Application_Client_ID            = azuread_application.meshcloud_metering.client_id
-    Client_Secret                    = "Execute `terraform output metering_client_secret` to see the password"
+    Client_Secret                    = var.create_password ? "Execute `terraform output metering_service_principal_password` to see the password" : "No password was created"
   }
 }
 
 output "application_client_secret" {
   description = "Client Secret Of the Application."
-  value       = azuread_application_password.application_pw.value
+  value       = var.create_password ? azuread_application_password.application_pw[0].value : null
   sensitive   = true
 }

--- a/modules/meshcloud-metering-service-principal/variables.tf
+++ b/modules/meshcloud-metering-service-principal/variables.tf
@@ -7,3 +7,14 @@ variable "assignment_scopes" {
   type        = list(string)
   description = "The scopes to which Service Principal permissions should be assigned to. Usually this is the management group id of form `/providers/Microsoft.Management/managementGroups/<tenantId>` that sits atop the subscriptions."
 }
+
+variable "create_password" {
+  type        = bool
+  description = "Create a password for the enterprise application."
+}
+
+variable "workload_identity_federation" {
+  default     = null
+  description = "Enable workload identity federation instead of using a password by providing these additional settings. Usually you should receive the required settings when attempting to configure a platform with workload identity federation in meshStack."
+  type        = object({ issuer = string, subject = string })
+}

--- a/modules/meshcloud-replicator-service-principal/auth.tf
+++ b/modules/meshcloud-replicator-service-principal/auth.tf
@@ -1,0 +1,40 @@
+//---------------------------------------------------------------------------
+// Create new client secret and associate it with the application
+//---------------------------------------------------------------------------
+resource "time_rotating" "replicator_secret_rotation" {
+  count = var.create_password ? 1 : 0
+
+  rotation_days = 365
+}
+
+resource "azuread_application_password" "application_pw" {
+  count = var.create_password ? 1 : 0
+
+  application_id = azuread_application.meshcloud_replicator.id
+  rotate_when_changed = {
+    rotation = time_rotating.replicator_secret_rotation[0].id
+  }
+}
+
+moved {
+  from = time_rotating.replicator_secret_rotation
+  to   = time_rotating.replicator_secret_rotation[0]
+}
+
+moved {
+  from = azuread_application_password.application_pw
+  to   = azuread_application_password.application_pw[0]
+}
+
+//---------------------------------------------------------------------------
+// Create federated identity credentials
+//---------------------------------------------------------------------------
+resource "azuread_application_federated_identity_credential" "meshcloud_replicator" {
+  count = var.workload_identity_federation == null ? 0 : 1
+
+  application_id = azuread_application.meshcloud_replicator.id
+  display_name   = var.service_principal_name
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = var.workload_identity_federation.issuer
+  subject        = var.workload_identity_federation.subject
+}

--- a/modules/meshcloud-replicator-service-principal/module.tf
+++ b/modules/meshcloud-replicator-service-principal/module.tf
@@ -132,20 +132,7 @@ resource "azuread_application" "meshcloud_replicator" {
 }
 
 //---------------------------------------------------------------------------
-// Create new client secret and associate it with the previous application
-//---------------------------------------------------------------------------
-resource "time_rotating" "replicator_secret_rotation" {
-  rotation_days = 365
-}
-resource "azuread_application_password" "application_pw" {
-  application_id = azuread_application.meshcloud_replicator.id
-  rotate_when_changed = {
-    rotation = time_rotating.replicator_secret_rotation.id
-  }
-}
-
-//---------------------------------------------------------------------------
-// Create new Enterprise Application and associate it with the previous application
+// Create new Enterprise Application and associate it with the application
 //---------------------------------------------------------------------------
 resource "azuread_service_principal" "meshcloud_replicator" {
   client_id = azuread_application.meshcloud_replicator.client_id

--- a/modules/meshcloud-replicator-service-principal/outputs.tf
+++ b/modules/meshcloud-replicator-service-principal/outputs.tf
@@ -3,12 +3,12 @@ output "credentials" {
   value = {
     Enterprise_Application_Object_ID = azuread_service_principal.meshcloud_replicator.id
     Application_Client_ID            = azuread_application.meshcloud_replicator.client_id
-    Client_Secret                    = "Execute `terraform output replicator_client_secret` to see the password"
+    Client_Secret                    = var.create_password ? "Execute `terraform output replicator_service_principal_password` to see the password" : "No password was created"
   }
 }
 
 output "application_client_secret" {
   description = "Client Secret Of the Application."
-  value       = azuread_application_password.application_pw.value
+  value       = var.create_password ? azuread_application_password.application_pw[0].value : null
   sensitive   = true
 }

--- a/modules/meshcloud-replicator-service-principal/variables.tf
+++ b/modules/meshcloud-replicator-service-principal/variables.tf
@@ -30,3 +30,14 @@ variable "replicator_rg_enabled" {
   default     = false
   description = "Whether the created replicator Service Principal should be usable for Azure Resource Group based replication."
 }
+
+variable "create_password" {
+  type        = bool
+  description = "Create a password for the enterprise application."
+}
+
+variable "workload_identity_federation" {
+  default     = null
+  description = "Enable workload identity federation instead of using a password by providing these additional settings. Usually you should receive the required settings when attempting to configure a platform with workload identity federation in meshStack."
+  type        = object({ issuer = string, subject = string })
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
-
 output "replicator_service_principal" {
   description = "Replicator Service Principal."
   value       = length(module.replicator_service_principal) > 0 ? module.replicator_service_principal[0].credentials : null

--- a/variables.tf
+++ b/variables.tf
@@ -80,3 +80,15 @@ variable "additional_permissions" {
   default     = []
   description = "Additional Subscription-Level Permissions the Service Principal needs."
 }
+
+variable "create_passwords" {
+  type        = bool
+  default     = true
+  description = "Create passwords for service principals."
+}
+
+variable "workload_identity_federation" {
+  default     = null
+  description = "Enable workload identity federation by creating federated credentials for enterprise applications. Usually you'd receive the required settings when attempting to configure a platform with workload identity federation in meshStack."
+  type        = object({ issuer = string, replicator_subject = string, kraken_subject = string })
+}


### PR DESCRIPTION
Allow metering and replicator service principals to use workload identity federation instead of passwords.