### PR TITLE
fix: sso integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ provide the SPN with access to the function.
   ]
 ```
 
+## Single Sign On (SSO) Integration
+
+>While this does not belong to a meshplatform, you can enable sso using this module. This is subject to change and sso can be moved out in the future.
+
+To login to meshStack with Microsoft Entra ID, you can create an SSO service principal by adding the following inputs when calling this module:
+
+```hcl
+sso_enabled = true
+
+# This is required as it will construct the redirect uri. A default has been added only so that it's not mandatory to setup sso (i.e. when sso_enabled = false)
+sso_meshstack_idp_domain = "sso.<domain>"
+```
+
 ## Contributing Guide
 
 Before opening a Pull Request, please do the following:
@@ -205,9 +218,11 @@ Before opening a Pull Request, please do the following:
 | <a name="input_replicator_enabled"></a> [replicator\_enabled](#input\_replicator\_enabled) | Whether to create replicator Service Principal or not. | `bool` | `true` | no |
 | <a name="input_replicator_rg_enabled"></a> [replicator\_rg\_enabled](#input\_replicator\_rg\_enabled) | Whether the created replicator Service Principal should be usable for Azure Resource Group based replication. Implicitly enables replicator\_enabled if set to true. | `bool` | `false` | no |
 | <a name="input_replicator_service_principal_name"></a> [replicator\_service\_principal\_name](#input\_replicator\_service\_principal\_name) | Service principal for managing subscriptions. Replicator is the name of the meshStack component. Name must be unique per Entra ID. | `string` | `"replicator"` | no |
-| <a name="input_sso_enabled"></a> [sso\_enabled](#input\_sso\_enabled) | Whether to create SSO Service Principal or not. | `bool` | `true` | no |
-| <a name="input_sso_meshstack_redirect_uri"></a> [sso\_meshstack\_redirect\_uri](#input\_sso\_meshstack\_redirect\_uri) | Redirect URI that was provided by meshcloud. It is individual per meshStack. | `string` | `"<replace with uri>"` | no |
-| <a name="input_sso_service_principal_name"></a> [sso\_service\_principal\_name](#input\_sso\_service\_principal\_name) | Service principal for Entra ID SSO. Name must be unique per Entra ID. | `string` | `"sso"` | no |
+| <a name="input_sso_app_role_assignment_required"></a> [sso\_app\_role\_assignment\_required](#input\_sso\_app\_role\_assignment\_required) | Whether all users can login using the created application (false), or only assigned users (true) | `bool` | `false` | no |
+| <a name="input_sso_enabled"></a> [sso\_enabled](#input\_sso\_enabled) | Whether to create SSO Service Principal. This service principal is used to integrate meshStack identity provider with your own identity provider. | `bool` | `false` | no |
+| <a name="input_sso_identity_provider_alias"></a> [sso\_identity\_provider\_alias](#input\_sso\_identity\_provider\_alias) | Identity provider alias. This value needs to be passed to meshcloud to configure the identity provider. | `string` | `"oidc"` | no |
+| <a name="input_sso_meshstack_idp_domain"></a> [sso\_meshstack\_idp\_domain](#input\_sso\_meshstack\_idp\_domain) | meshStack identity provider domain that was provided by meshcloud. It is individual per meshStack. In most cases it is sso.<portal-domain> | `string` | `"replaceme"` | no |
+| <a name="input_sso_service_principal_name"></a> [sso\_service\_principal\_name](#input\_sso\_service\_principal\_name) | Service principal for Entra ID SSO. Name must be unique per Entra ID. | `string` | `"meshcloud SSO"` | no |
 | <a name="input_workload_identity_federation"></a> [workload\_identity\_federation](#input\_workload\_identity\_federation) | Enable workload identity federation by creating federated credentials for enterprise applications. Usually you'd receive the required settings when attempting to configure a platform with workload identity federation in meshStack. | `object({ issuer = string, replicator_subject = string, kraken_subject = string })` | `null` | no |
 
 ## Outputs
@@ -221,6 +236,7 @@ Before opening a Pull Request, please do the following:
 | <a name="output_metering_service_principal_password"></a> [metering\_service\_principal\_password](#output\_metering\_service\_principal\_password) | Password for Metering Service Principal. |
 | <a name="output_replicator_service_principal"></a> [replicator\_service\_principal](#output\_replicator\_service\_principal) | Replicator Service Principal. |
 | <a name="output_replicator_service_principal_password"></a> [replicator\_service\_principal\_password](#output\_replicator\_service\_principal\_password) | Password for Replicator Service Principal. |
-| <a name="output_sso_service_principal"></a> [sso\_service\_principal](#output\_sso\_service\_principal) | SSO Service Principal. |
+| <a name="output_sso_discovery_url"></a> [sso\_discovery\_url](#output\_sso\_discovery\_url) | SSO applications's discovery url (OpenID Connect metadata document) |
+| <a name="output_sso_service_principal_client_id"></a> [sso\_service\_principal\_client\_id](#output\_sso\_service\_principal\_client\_id) | SSO Service Principal. |
 | <a name="output_sso_service_principal_password"></a> [sso\_service\_principal\_password](#output\_sso\_service\_principal\_password) | Password for SSO Service Principal. |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -100,8 +100,10 @@ module "sso_service_principal" {
   count  = var.sso_enabled ? 1 : 0
   source = "./modules/meshcloud-sso/"
 
-  service_principal_name = var.sso_service_principal_name
-  meshstack_redirect_uri = var.sso_meshstack_redirect_uri
+  service_principal_name       = var.sso_service_principal_name
+  meshstack_idp_domain         = var.sso_meshstack_idp_domain
+  identity_provider_alias      = var.sso_identity_provider_alias
+  app_role_assignment_required = var.sso_app_role_assignment_required
 }
 
 # facilitate migration from v0.1.0 of the module

--- a/modules/meshcloud-sso/README.md
+++ b/modules/meshcloud-sso/README.md
@@ -5,7 +5,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | 2.46.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.81.0 |
 
 ## Providers
 
@@ -21,24 +20,28 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azuread_app_role_assignment.meshcloud_sso_user_read](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/resources/app_role_assignment) | resource |
 | [azuread_application.meshcloud_sso](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/resources/application) | resource |
 | [azuread_application_password.meshcloud_sso](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/resources/application_password) | resource |
+| [azuread_service_principal.meshcloud_sso](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/resources/service_principal) | resource |
 | [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/application_published_app_ids) | data source |
 | [azuread_application_template.enterprise_app](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/application_template) | data source |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/2.46.0/docs/data-sources/service_principal) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_meshstack_redirect_uri"></a> [meshstack\_redirect\_uri](#input\_meshstack\_redirect\_uri) | Redirect URI that was provided by meshcloud. It is individual per meshStack. | `string` | n/a | yes |
-| <a name="input_service_principal_name"></a> [service\_principal\_name](#input\_service\_principal\_name) | Service principal name. | `string` | n/a | yes |
+| <a name="input_app_role_assignment_required"></a> [app\_role\_assignment\_required](#input\_app\_role\_assignment\_required) | Whether all users can login using the created application (false), or only assigned users (true) | `bool` | `false` | no |
+| <a name="input_identity_provider_alias"></a> [identity\_provider\_alias](#input\_identity\_provider\_alias) | Identity provider alias. This value needs to be passed to meshcloud to configure the identity provider. | `string` | `"oidc"` | no |
+| <a name="input_meshstack_idp_domain"></a> [meshstack\_idp\_domain](#input\_meshstack\_idp\_domain) | meshStack identity provider domain that was provided by meshcloud. It is individual per meshStack. In most cases it is sso.<portal-domain> | `string` | n/a | yes |
+| <a name="input_service_principal_name"></a> [service\_principal\_name](#input\_service\_principal\_name) | Service principal for Entra ID SSO. Name must be unique per Entra ID. | `string` | `"meshcloud SSO"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_application_client_secret"></a> [application\_client\_secret](#output\_application\_client\_secret) | Password for the application registration. |
-| <a name="output_credentials"></a> [credentials](#output\_credentials) | Service Principal application id and object id |
+| <a name="output_application_client_id"></a> [application\_client\_id](#output\_application\_client\_id) | n/a |
+| <a name="output_application_password"></a> [application\_password](#output\_application\_password) | Password for the SSO application. |
+| <a name="output_discovery_url"></a> [discovery\_url](#output\_discovery\_url) | SSO applications's discovery url (OpenID Connect metadata document) |
 <!-- END_TF_DOCS -->

--- a/modules/meshcloud-sso/outputs.tf
+++ b/modules/meshcloud-sso/outputs.tf
@@ -1,13 +1,16 @@
-output "credentials" {
-  description = "Service Principal application id and object id"
-  value = {
-    Enterprise_Application_Object_ID = azuread_application.meshcloud_sso.object_id
-    Application_Client_ID            = azuread_application.meshcloud_sso.client_id
-  }
+output "application_client_id" {
+  value = azuread_application.meshcloud_sso.client_id
 }
 
-output "application_client_secret" {
-  description = "Password for the application registration."
-  value       = azuread_application_password.meshcloud_sso.value
+output "application_password" {
+  description = "Password for the SSO application."
   sensitive   = true
+  value       = azuread_application_password.meshcloud_sso.value
+}
+
+data "azuread_client_config" "current" {}
+
+output "discovery_url" {
+  description = "SSO applications's discovery url (OpenID Connect metadata document)"
+  value       = "https://login.microsoftonline.com/${data.azuread_client_config.current.tenant_id}/v2.0/.well-known/openid-configuration"
 }

--- a/modules/meshcloud-sso/variables.tf
+++ b/modules/meshcloud-sso/variables.tf
@@ -1,9 +1,22 @@
 variable "service_principal_name" {
   type        = string
-  description = "Service principal name."
+  default     = "meshcloud SSO"
+  description = "Service principal for Entra ID SSO. Name must be unique per Entra ID."
 }
 
-variable "meshstack_redirect_uri" {
+variable "meshstack_idp_domain" {
   type        = string
-  description = "Redirect URI that was provided by meshcloud. It is individual per meshStack."
+  description = "meshStack identity provider domain that was provided by meshcloud. It is individual per meshStack. In most cases it is sso.<portal-domain>"
+}
+
+variable "identity_provider_alias" {
+  type        = string
+  default     = "oidc"
+  description = "Identity provider alias. This value needs to be passed to meshcloud to configure the identity provider."
+}
+
+variable "app_role_assignment_required" {
+  type        = bool
+  default     = false
+  description = "Whether all users can login using the created application (false), or only assigned users (true)"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,14 +31,20 @@ output "metering_service_principal_password" {
   sensitive   = true
 }
 
-output "sso_service_principal" {
+output "sso_service_principal_client_id" {
   description = "SSO Service Principal."
-  value       = length(module.sso_service_principal) > 0 ? module.sso_service_principal[0].credentials : null
+  value       = length(module.sso_service_principal) > 0 ? module.sso_service_principal[0].application_client_id : null
 }
 
 output "sso_service_principal_password" {
   description = "Password for SSO Service Principal."
-  value       = length(module.sso_service_principal) > 0 ? module.sso_service_principal[0].application_client_secret : null
+  value       = length(module.sso_service_principal) > 0 ? module.sso_service_principal[0].application_password : null
+  sensitive   = true
+}
+
+output "sso_discovery_url" {
+  description = "SSO applications's discovery url (OpenID Connect metadata document)"
+  value       = length(module.sso_service_principal) > 0 ? module.sso_service_principal[0].discovery_url : null
   sensitive   = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,28 +37,37 @@ variable "metering_assignment_scopes" {
   description = "Names or UUIDs of the Management Groups that kraken should collect costs for."
 }
 
+# SSO inputs
+
 variable "sso_enabled" {
   type        = bool
-  default     = true
-  description = "Whether to create SSO Service Principal or not."
+  default     = false
+  description = "Whether to create SSO Service Principal. This service principal is used to integrate meshStack identity provider with your own identity provider."
 }
 
 variable "sso_service_principal_name" {
   type        = string
-  default     = "sso"
+  default     = "meshcloud SSO"
   description = "Service principal for Entra ID SSO. Name must be unique per Entra ID."
 }
 
-variable "sso_meshstack_redirect_uri" {
+variable "sso_meshstack_idp_domain" {
   type        = string
-  default     = "<replace with uri>"
-  description = "Redirect URI that was provided by meshcloud. It is individual per meshStack."
+  default     = "replaceme"
+  description = "meshStack identity provider domain that was provided by meshcloud. It is individual per meshStack. In most cases it is sso.<portal-domain>"
 }
 
-# ---------------------------------------------------------------------------------------------------------------------
-# OPTIONAL PARAMETERS
-# These parameters have reasonable defaults.
-# ---------------------------------------------------------------------------------------------------------------------
+variable "sso_identity_provider_alias" {
+  type        = string
+  default     = "oidc"
+  description = "Identity provider alias. This value needs to be passed to meshcloud to configure the identity provider."
+}
+
+variable "sso_app_role_assignment_required" {
+  type        = bool
+  default     = false
+  description = "Whether all users can login using the created application (false), or only assigned users (true)"
+}
 
 variable "replicator_enabled" {
   type        = bool


### PR DESCRIPTION
End to end sso service principal creation with required settings

This should also provide outputs necessary to configure the identity provider from meshcloud's side