### PR TITLE
Feature/application owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New configuration option `applications_owners` to add application owners to applications and service principals
+
 ## [v0.9.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Before opening a Pull Request, please do the following:
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.111.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
 
 ## Modules
 
@@ -206,6 +206,7 @@ Before opening a Pull Request, please do the following:
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
 | <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the replicator Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
+| <a name="input_application_owners"></a> [application\_owners](#input\_application\_owners) | List of user principals that should be added as owners to the created service principals. | `list(string)` | `[]` | no |
 | <a name="input_can_cancel_subscriptions_in_scopes"></a> [can\_cancel\_subscriptions\_in\_scopes](#input\_can\_cancel\_subscriptions\_in\_scopes) | The scopes to which Service Principal cancel subscription permission is assigned to. List of management group id of form `/providers/Microsoft.Management/managementGroups/<mgmtGroupId>/`. | `list(string)` | `[]` | no |
 | <a name="input_can_delete_rgs_in_scopes"></a> [can\_delete\_rgs\_in\_scopes](#input\_can\_delete\_rgs\_in\_scopes) | The scopes to which Service Principal delete resource group permission is assigned to. Only relevant when `replicator_rg_enabled`. List of subscription scopes of form `/subscriptions/<subscriptionId>`. | `list(string)` | `[]` | no |
 | <a name="input_create_passwords"></a> [create\_passwords](#input\_create\_passwords) | Create passwords for service principals. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,8 @@ module "replicator_service_principal" {
     issuer  = var.workload_identity_federation.issuer,
     subject = var.workload_identity_federation.replicator_subject
   }
+
+  application_owners = var.application_owners
 }
 
 module "mca_service_principal" {
@@ -80,6 +82,8 @@ module "mca_service_principal" {
   billing_account_name = var.mca.billing_account_name
   billing_profile_name = var.mca.billing_profile_name
   invoice_section_name = var.mca.invoice_section_name
+
+  application_owners = var.application_owners
 }
 
 module "metering_service_principal" {
@@ -94,6 +98,8 @@ module "metering_service_principal" {
     issuer  = var.workload_identity_federation.issuer,
     subject = var.workload_identity_federation.kraken_subject
   }
+
+  application_owners = var.application_owners
 }
 
 module "sso_service_principal" {
@@ -104,6 +110,8 @@ module "sso_service_principal" {
   meshstack_idp_domain         = var.sso_meshstack_idp_domain
   identity_provider_alias      = var.sso_identity_provider_alias
   app_role_assignment_required = var.sso_app_role_assignment_required
+
+  application_owners = var.application_owners
 }
 
 # facilitate migration from v0.1.0 of the module

--- a/modules/meshcloud-mca-service-principal/module.tf
+++ b/modules/meshcloud-mca-service-principal/module.tf
@@ -30,11 +30,13 @@ data "azurerm_billing_mca_account_scope" "mca" {
 resource "azuread_application" "mca" {
   for_each     = toset(var.service_principal_names)
   display_name = each.key
+  owners       = var.application_owners
 }
 
 resource "azuread_service_principal" "mca" {
   for_each  = toset(var.service_principal_names)
   client_id = azuread_application.mca[each.key].client_id
+  owners    = var.application_owners
 }
 
 data "azapi_resource_list" "billing_role_definitions" {

--- a/modules/meshcloud-mca-service-principal/variables.tf
+++ b/modules/meshcloud-mca-service-principal/variables.tf
@@ -13,3 +13,9 @@ variable "billing_profile_name" {
 variable "invoice_section_name" {
   type = string
 }
+
+variable "application_owners" {
+  type        = list(string)
+  description = "List of user principals that should be added as owners to the mca service principal."
+  default     = []
+}

--- a/modules/meshcloud-metering-service-principal/README.md
+++ b/modules/meshcloud-metering-service-principal/README.md
@@ -12,8 +12,8 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.111.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.11.2 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.12.0 |
 
 ## Modules
 
@@ -34,6 +34,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_application_owners"></a> [application\_owners](#input\_application\_owners) | List of user principals that should be added as owners to the metering service principal. | `list(string)` | `[]` | no |
 | <a name="input_assignment_scopes"></a> [assignment\_scopes](#input\_assignment\_scopes) | The scopes to which Service Principal permissions should be assigned to. Usually this is the management group id of form `/providers/Microsoft.Management/managementGroups/<tenantId>` that sits atop the subscriptions. | `list(string)` | n/a | yes |
 | <a name="input_create_password"></a> [create\_password](#input\_create\_password) | Create a password for the enterprise application. | `bool` | n/a | yes |
 | <a name="input_service_principal_name"></a> [service\_principal\_name](#input\_service\_principal\_name) | Service principal name. Must be unique per Entra ID. | `string` | n/a | yes |

--- a/modules/meshcloud-metering-service-principal/module.tf
+++ b/modules/meshcloud-metering-service-principal/module.tf
@@ -32,6 +32,7 @@ resource "azurerm_role_assignment" "meshcloud_metering" {
 //---------------------------------------------------------------------------
 resource "azuread_application" "meshcloud_metering" {
   display_name = var.service_principal_name
+  owners       = var.application_owners
 
   feature_tags {
     enterprise = true
@@ -50,6 +51,7 @@ resource "azuread_application" "meshcloud_metering" {
 //---------------------------------------------------------------------------
 resource "azuread_service_principal" "meshcloud_metering" {
   client_id = azuread_application.meshcloud_metering.client_id
+  owners    = var.application_owners
   feature_tags {
     enterprise = true
   }

--- a/modules/meshcloud-metering-service-principal/variables.tf
+++ b/modules/meshcloud-metering-service-principal/variables.tf
@@ -18,3 +18,9 @@ variable "workload_identity_federation" {
   description = "Enable workload identity federation instead of using a password by providing these additional settings. Usually you should receive the required settings when attempting to configure a platform with workload identity federation in meshStack."
   type        = object({ issuer = string, subject = string })
 }
+
+variable "application_owners" {
+  type        = list(string)
+  description = "List of user principals that should be added as owners to the metering service principal."
+  default     = []
+}

--- a/modules/meshcloud-replicator-service-principal/README.md
+++ b/modules/meshcloud-replicator-service-principal/README.md
@@ -12,9 +12,9 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.111.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.113.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.11.2 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.12.0 |
 
 ## Modules
 
@@ -51,6 +51,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_permissions"></a> [additional\_permissions](#input\_additional\_permissions) | Additional Subscription-Level Permissions the Service Principal needs. | `list(string)` | `[]` | no |
 | <a name="input_additional_required_resource_accesses"></a> [additional\_required\_resource\_accesses](#input\_additional\_required\_resource\_accesses) | Additional AAD-Level Resource Accesses the Service Principal needs. | `list(object({ resource_app_id = string, resource_accesses = list(object({ id = string, type = string })) }))` | `[]` | no |
+| <a name="input_application_owners"></a> [application\_owners](#input\_application\_owners) | List of user principals that should be added as owners to the replicator service principal. | `list(string)` | `[]` | no |
 | <a name="input_assignment_scopes"></a> [assignment\_scopes](#input\_assignment\_scopes) | The scopes to which Service Principal permissions is assigned to. List of management group id of form `/providers/Microsoft.Management/managementGroups/<mgmtGroupId>/`. | `list(string)` | n/a | yes |
 | <a name="input_can_cancel_subscriptions_in_scopes"></a> [can\_cancel\_subscriptions\_in\_scopes](#input\_can\_cancel\_subscriptions\_in\_scopes) | The scopes to which Service Principal cancel subscription permission is assigned to. List of management group id of form `/providers/Microsoft.Management/managementGroups/<mgmtGroupId>/`. | `list(string)` | `[]` | no |
 | <a name="input_can_delete_rgs_in_scopes"></a> [can\_delete\_rgs\_in\_scopes](#input\_can\_delete\_rgs\_in\_scopes) | The scopes to which Service Principal delete resource group permission is assigned to. Only relevant when `replicator_rg_enabled`. List of subscription scopes of form `/subscriptions/<subscriptionId>`. | `list(string)` | `[]` | no |

--- a/modules/meshcloud-replicator-service-principal/module.tf
+++ b/modules/meshcloud-replicator-service-principal/module.tf
@@ -116,6 +116,7 @@ data "azuread_application_template" "enterprise_app" {
 }
 resource "azuread_application" "meshcloud_replicator" {
   display_name = var.service_principal_name
+  owners       = var.application_owners
   template_id  = data.azuread_application_template.enterprise_app.template_id
   feature_tags {
     enterprise = true
@@ -168,6 +169,7 @@ resource "azuread_application" "meshcloud_replicator" {
 //---------------------------------------------------------------------------
 resource "azuread_service_principal" "meshcloud_replicator" {
   client_id = azuread_application.meshcloud_replicator.client_id
+  owners    = var.application_owners
   feature_tags {
     enterprise = true
   }

--- a/modules/meshcloud-replicator-service-principal/variables.tf
+++ b/modules/meshcloud-replicator-service-principal/variables.tf
@@ -53,3 +53,9 @@ variable "workload_identity_federation" {
   description = "Enable workload identity federation instead of using a password by providing these additional settings. Usually you should receive the required settings when attempting to configure a platform with workload identity federation in meshStack."
   type        = object({ issuer = string, subject = string })
 }
+
+variable "application_owners" {
+  type        = list(string)
+  description = "List of user principals that should be added as owners to the replicator service principal."
+  default     = []
+}

--- a/modules/meshcloud-sso/README.md
+++ b/modules/meshcloud-sso/README.md
@@ -33,6 +33,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_role_assignment_required"></a> [app\_role\_assignment\_required](#input\_app\_role\_assignment\_required) | Whether all users can login using the created application (false), or only assigned users (true) | `bool` | `false` | no |
+| <a name="input_application_owners"></a> [application\_owners](#input\_application\_owners) | List of user principals that should be added as owners to the sso service principal. | `list(string)` | `[]` | no |
 | <a name="input_identity_provider_alias"></a> [identity\_provider\_alias](#input\_identity\_provider\_alias) | Identity provider alias. This value needs to be passed to meshcloud to configure the identity provider. | `string` | `"oidc"` | no |
 | <a name="input_meshstack_idp_domain"></a> [meshstack\_idp\_domain](#input\_meshstack\_idp\_domain) | meshStack identity provider domain that was provided by meshcloud. It is individual per meshStack. In most cases it is sso.<portal-domain> | `string` | n/a | yes |
 | <a name="input_service_principal_name"></a> [service\_principal\_name](#input\_service\_principal\_name) | Service principal for Entra ID SSO. Name must be unique per Entra ID. | `string` | `"meshcloud SSO"` | no |

--- a/modules/meshcloud-sso/module.tf
+++ b/modules/meshcloud-sso/module.tf
@@ -29,6 +29,7 @@ data "azuread_application_template" "enterprise_app" {
 
 resource "azuread_application" "meshcloud_sso" {
   display_name = var.service_principal_name
+  owners       = var.application_owners
   template_id  = data.azuread_application_template.enterprise_app.template_id
   feature_tags {
     enterprise = true
@@ -54,6 +55,7 @@ resource "azuread_service_principal" "meshcloud_sso" {
   use_existing                 = true
   app_role_assignment_required = var.app_role_assignment_required
   client_id                    = azuread_application.meshcloud_sso.client_id
+  owners                       = var.application_owners
 }
 
 resource "azuread_application_password" "meshcloud_sso" {

--- a/modules/meshcloud-sso/variables.tf
+++ b/modules/meshcloud-sso/variables.tf
@@ -20,3 +20,9 @@ variable "app_role_assignment_required" {
   default     = false
   description = "Whether all users can login using the created application (false), or only assigned users (true)"
 }
+
+variable "application_owners" {
+  type        = list(string)
+  description = "List of user principals that should be added as owners to the sso service principal."
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,9 @@ variable "mca" {
   })
   default = null
 }
+
+variable "application_owners" {
+  type        = list(string)
+  description = "List of user principals that should be added as owners to the created service principals."
+  default     = []
+}


### PR DESCRIPTION
Following our organizational policies and Microsoft's recommendation to have at least two application owners, this feature adds the option to assign owners to the meshStack service principals via terraform.