### PR TITLE
feat: upgrade minimum terraform provider versions

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -19,3 +19,7 @@ output:
 sort:
   enabled: true
   by: name
+
+sections:
+  hide: # we remove the providers section because the actual provider used depends on the local build environment, we only document version constraints
+    - providers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgraded minimum terraform provider versions
+
 ## [v0.10.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -175,13 +175,6 @@ Before opening a Pull Request, please do the following:
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.11.0 |
 
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.11.0 |
-
 ## Modules
 
 | Name | Source | Version |

--- a/README.md
+++ b/README.md
@@ -172,15 +172,15 @@ Before opening a Pull Request, please do the following:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.1 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >=1.13.1 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=2.46.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.81.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.5.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.11.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = ">=4.11.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=2.46.0"
+      version = ">=3.0.2"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/modules/meshcloud-mca-service-principal/module.tf
+++ b/modules/meshcloud-mca-service-principal/module.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = ">=4.11.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=2.46.0"
+      version = ">=3.0.2"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/modules/meshcloud-metering-service-principal/README.md
+++ b/modules/meshcloud-metering-service-principal/README.md
@@ -4,15 +4,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=2.46.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.81.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.5.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.11.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 
 ## Modules

--- a/modules/meshcloud-metering-service-principal/README.md
+++ b/modules/meshcloud-metering-service-principal/README.md
@@ -7,14 +7,6 @@
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.11.0 |
 
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.11.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
-
 ## Modules
 
 No modules.

--- a/modules/meshcloud-metering-service-principal/module.tf
+++ b/modules/meshcloud-metering-service-principal/module.tf
@@ -6,11 +6,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = ">=4.11.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=2.46.0"
+      version = ">=3.0.2"
     }
   }
 }
@@ -22,7 +22,7 @@ resource "azurerm_role_assignment" "meshcloud_metering" {
   for_each             = toset(var.assignment_scopes)
   scope                = each.key
   role_definition_name = "Cost Management Reader"
-  principal_id         = azuread_service_principal.meshcloud_metering.id
+  principal_id         = azuread_service_principal.meshcloud_metering.object_id
   depends_on           = [azuread_service_principal.meshcloud_metering]
 }
 

--- a/modules/meshcloud-metering-service-principal/outputs.tf
+++ b/modules/meshcloud-metering-service-principal/outputs.tf
@@ -1,7 +1,7 @@
 output "credentials" {
   description = "Service Principal application id and object id"
   value = {
-    Enterprise_Application_Object_ID = azuread_service_principal.meshcloud_metering.id
+    Enterprise_Application_Object_ID = azuread_service_principal.meshcloud_metering.object_id
     Application_Client_ID            = azuread_application.meshcloud_metering.client_id
     Client_Secret                    = var.create_password ? "Execute `terraform output metering_service_principal_password` to see the password" : "No password was created"
   }

--- a/modules/meshcloud-replicator-service-principal/README.md
+++ b/modules/meshcloud-replicator-service-principal/README.md
@@ -4,15 +4,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=2.46.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.81.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.5.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.11.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 

--- a/modules/meshcloud-replicator-service-principal/README.md
+++ b/modules/meshcloud-replicator-service-principal/README.md
@@ -7,15 +7,6 @@
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.11.0 |
 
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.11.0 |
-| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
-
 ## Modules
 
 No modules.

--- a/modules/meshcloud-replicator-service-principal/module.tf
+++ b/modules/meshcloud-replicator-service-principal/module.tf
@@ -6,11 +6,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.81.0"
+      version = ">=4.11.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=2.46.0"
+      version = ">=3.0.2"
     }
   }
 }
@@ -187,20 +187,20 @@ resource "azurerm_role_assignment" "meshcloud_replicator" {
   for_each           = toset(var.assignment_scopes)
   scope              = each.key
   role_definition_id = azurerm_role_definition.meshcloud_replicator.role_definition_resource_id
-  principal_id       = azuread_service_principal.meshcloud_replicator.id
+  principal_id       = azuread_service_principal.meshcloud_replicator.object_id
 }
 
 resource "azurerm_role_assignment" "meshcloud_replicator_subscription_canceler" {
   for_each           = toset(var.can_cancel_subscriptions_in_scopes)
   scope              = each.key
   role_definition_id = azurerm_role_definition.meshcloud_replicator_subscription_canceler.role_definition_resource_id
-  principal_id       = azuread_service_principal.meshcloud_replicator.id
+  principal_id       = azuread_service_principal.meshcloud_replicator.object_id
 }
 
 resource "azurerm_role_assignment" "meshcloud_replicator_rg_deleter" {
   for_each     = toset(var.can_delete_rgs_in_scopes)
   scope        = each.key
-  principal_id = azuread_service_principal.meshcloud_replicator.id
+  principal_id = azuread_service_principal.meshcloud_replicator.object_id
 
   # The azurerm provider requires this must be a scoped id, so unfortuantely we need to construct the id of the role
   # definition at the assignment scope in order to make this stable for subsequent terraform apply's.

--- a/modules/meshcloud-replicator-service-principal/outputs.tf
+++ b/modules/meshcloud-replicator-service-principal/outputs.tf
@@ -1,7 +1,7 @@
 output "credentials" {
   description = "Service Principal application id and object id"
   value = {
-    Enterprise_Application_Object_ID = azuread_service_principal.meshcloud_replicator.id
+    Enterprise_Application_Object_ID = azuread_service_principal.meshcloud_replicator.object_id
     Application_Client_ID            = azuread_application.meshcloud_replicator.client_id
     Client_Secret                    = var.create_password ? "Execute `terraform output replicator_service_principal_password` to see the password" : "No password was created"
   }

--- a/modules/meshcloud-sso/README.md
+++ b/modules/meshcloud-sso/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=2.46.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
 
 ## Providers
 

--- a/modules/meshcloud-sso/README.md
+++ b/modules/meshcloud-sso/README.md
@@ -6,12 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > 1.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.0.2 |
 
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.0.2 |
-
 ## Modules
 
 No modules.

--- a/modules/meshcloud-sso/module.tf
+++ b/modules/meshcloud-sso/module.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=2.46.0"
+      version = ">=3.0.2"
     }
   }
 }


### PR DESCRIPTION
one key change in azurerm is that service principals now need to be
referenced by object_id for assignment instead of by id because
the provider changed the internal format
