### PR TITLE
Update module.tf

### DIFF
--- a/modules/meshcloud-mca-service-principal/module.tf
+++ b/modules/meshcloud-mca-service-principal/module.tf
@@ -15,7 +15,7 @@ terraform {
     }
     azapi = {
       source  = "Azure/azapi"
-      version = ">=1.13.1"
+      version = "1.13.1"
     }
   }
 }


### PR DESCRIPTION
someone have to test the module with a newer version of azapi. It does not work anymore on newer version.

Root Cause: The azapi provider version 2.9.0 has changed behavior compared to earlier versions. In newer versions of azapi, the output attribute of azapi_resource_list returns a native Terraform object instead of a JSON string. The Problem:
- Lines 49-52 in the module use jsondecode() on data.azapi_resource_list.billing_role_definitions.output
- But in azapi v2.x, .output is already an object, not a JSON string
- The error message confirms this: data.azapi_resource_list.billing_role_definitions.output is object with 1 attribute "value" This is a breaking change introduced in azapi provider 2.0. The module was written for azapi 1.x where .output was a JSON string that needed decoding.