### PR TITLE
refactor: remove Azure Blueprint IAM permissions

### DIFF
--- a/modules/meshcloud-replicator-service-principal/module.tf
+++ b/modules/meshcloud-replicator-service-principal/module.tf
@@ -35,12 +35,8 @@ resource "azurerm_role_definition" "meshcloud_replicator" {
       "Microsoft.Authorization/roleAssignments/*",
       "Microsoft.Authorization/roleDefinitions/read",
 
-      # Assigning Blueprints
-      "Microsoft.Resources/deployments/*",
-      "Microsoft.Blueprint/blueprintAssignments/*",
-      "Microsoft.Resources/subscriptions/resourceGroups/read",
-
-      # Fetching Blueprints
+      # Assigning Subscriptions to Management Groups
+      # managementGroups/read and descendants/read are required for hierarchical management group assignment
       "Microsoft.Management/managementGroups/read",
       "Microsoft.Management/managementGroups/descendants/read",
 
@@ -56,6 +52,7 @@ resource "azurerm_role_definition" "meshcloud_replicator" {
       var.replicator_rg_enabled ? [
         # Additional permission if this principal should be used for
         # Resource Group Azure replication as well
+        "Microsoft.Resources/subscriptions/resourceGroups/read",
         "Microsoft.Resources/subscriptions/resourceGroups/write"
       ] : [],
       var.additional_permissions


### PR DESCRIPTION
Azure Blueprints have been removed from meshStack (see meshcloud/meshfed-release#9852). This PR removes the Blueprint-related IAM permissions (Microsoft.Blueprint/blueprintAssignments/*, Microsoft.Resources/deployments/*, fetching management group permissions) that were only needed for Azure Blueprint support.

Part of cleanup tracked in meshcloud/janny#1024.